### PR TITLE
fix: npm publication workflow improvements

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -109,6 +109,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [ Build ]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    permissions:
+      id-token: write
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -134,5 +136,3 @@ jobs:
         run: npm run generate:workdir
       - name: "Publish package"
         run: npm publish --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -130,6 +130,8 @@ jobs:
             ${{ runner.os }}-
       - name: "Install dependencies"
         run: npm ci --no-progress
+      - name: "Generate library"
+        run: npm run generate:workdir
       - name: "Publish package"
         run: npm publish --tag latest
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tmorin/plantuml-libs",
-  "version": "18.0.0",
+  "version": "18.0.1-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tmorin/plantuml-libs",
-      "version": "18.0.0",
+      "version": "18.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "glob": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmorin/plantuml-libs",
-  "version": "18.0.0",
+  "version": "18.0.1-alpha.0",
   "description": "A set of resources for [PlantUML](https://plantuml.com) to define diagrams for AWS, Azure, EIP ...",
   "license": "MIT",
   "homepage": "https://github.com/tmorin/plantuml-libs#readme",


### PR DESCRIPTION
## Changes

- Add missing `npm run generate:workdir` step to NpmPublication job
- Switch to OIDC trusted publishers for secure npm authentication
- Remove NODE_AUTH_TOKEN secret (replaced by OIDC)

## Why

The NpmPublication job was failing because it tried to publish without generating the distribution folder. Additionally, this switches to the more secure OIDC trusted publisher approach instead of long-lived tokens.

## Next Steps

1. Set up trusted publisher on npmjs.com:
   - https://www.npmjs.com/package/@tmorin/plantuml-libs/settings/trusted-publishers
   - Add GitHub Actions trusted publisher: tmorin/plantuml-libs/continuous-integration.yaml

2. After merge, create a release tag to test the publication flow