### PR TITLE
fix(ci): grant read access for npm trusted publishing

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -111,11 +111,12 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     permissions:
       id-token: write
+      contents: read
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
       - name: "Setup node"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- add contents: read to the NpmPublication job permissions
- keep OIDC trusted publishing enabled
- update actions/setup-node to v6

## Why
Explicit job permissions removed the default repository read access, so actions/checkout needs contents: read in the npm publish job.