### PR TITLE
fix(test): stabilize resolver tests

### DIFF
--- a/scripts/resolve-aws-icons.mjs
+++ b/scripts/resolve-aws-icons.mjs
@@ -2,10 +2,11 @@
 
 import fetch from "node-fetch"
 import * as cheerio from "cheerio"
+import { fileURLToPath } from "url"
 
-async function fetchLatestAWSIconPackage() {
+async function fetchLatestAWSIconPackage(fetchImpl = fetch) {
   const url = "https://aws.amazon.com/architecture/icons/"
-  const response = await fetch(url)
+  const response = await fetchImpl(url)
 
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
@@ -68,14 +69,16 @@ async function fetchLatestAWSIconPackage() {
   }
 }
 
-;(async () => {
-  try {
-    const result = await fetchLatestAWSIconPackage()
-    console.log(JSON.stringify(result, null, 2))
-  } catch (error) {
-    console.error(error.message)
-    process.exit(1)
-  }
-})()
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  ;(async () => {
+    try {
+      const result = await fetchLatestAWSIconPackage()
+      console.log(JSON.stringify(result, null, 2))
+    } catch (error) {
+      console.error(error.message)
+      process.exit(1)
+    }
+  })()
+}
 
 export default fetchLatestAWSIconPackage

--- a/scripts/resolve-azure-icons.mjs
+++ b/scripts/resolve-azure-icons.mjs
@@ -2,10 +2,11 @@
 
 import fetch from "node-fetch"
 import * as cheerio from "cheerio"
+import { fileURLToPath } from "url"
 
-async function fetchLatestAzureIconPackage() {
+async function fetchLatestAzureIconPackage(fetchImpl = fetch) {
   const url = "https://learn.microsoft.com/en-us/azure/architecture/icons/"
-  const response = await fetch(url)
+  const response = await fetchImpl(url)
 
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
@@ -48,14 +49,16 @@ async function fetchLatestAzureIconPackage() {
   }
 }
 
-;(async () => {
-  try {
-    const result = await fetchLatestAzureIconPackage()
-    console.log(JSON.stringify(result, null, 2))
-  } catch (error) {
-    console.error(error.message)
-    process.exit(1)
-  }
-})()
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  ;(async () => {
+    try {
+      const result = await fetchLatestAzureIconPackage()
+      console.log(JSON.stringify(result, null, 2))
+    } catch (error) {
+      console.error(error.message)
+      process.exit(1)
+    }
+  })()
+}
 
 export default fetchLatestAzureIconPackage

--- a/test/fixtures/azure-valid.html
+++ b/test/fixtures/azure-valid.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Azure Architecture Icons</title>
+</head>
+<body>
+    <a href="https://arch-center.azureedge.net/icons/Azure_Public_Service_Icons_V23.zip">Azure icons</a>
+</body>
+</html>

--- a/test/fixtures/valid.html
+++ b/test/fixtures/valid.html
@@ -4,7 +4,6 @@
     <title>AWS Architecture Icons</title>
 </head>
 <body>
-    <a href="https://d1.awsstatic.com/onedam/.../architecture-icons/Asset-Package_02312025.<hash>.zip">Icon Package</a>
+    <a href="https://d1.awsstatic.com/onedam/marketing-channels/website/aws/en_US/architecture/approved/architecture-icons/Icon-package_01302026.31b40d126ed27079b708594940ad577a86150582.zip">Icon Package</a>
 </body>
 </html>
-

--- a/test/resolve-aws-icons.spec.mjs
+++ b/test/resolve-aws-icons.spec.mjs
@@ -1,18 +1,26 @@
 import { describe, it } from "mocha"
 import fetchLatestAWSIconPackage from "../scripts/resolve-aws-icons.mjs"
 import assert from "assert"
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+function mockFetch(html) {
+  return async () => ({
+    ok: true,
+    text: async () => html,
+  })
+}
 
 describe("fetchLatestAWSIconPackage", () => {
-  it("should fetch and parse the latest Icon Package from the live AWS website", async () => {
-    const result = await fetchLatestAWSIconPackage()
+  it("should fetch and parse the latest Icon Package", async () => {
+    const html = readFileSync(resolve("test/fixtures/valid.html"), "utf8")
+    const result = await fetchLatestAWSIconPackage(mockFetch(html))
 
-    assert.ok(result.newVersion.startsWith("aws-q"), "newVersion should start with 'aws-q'")
-    assert.ok(
-      result.downloadUrl.includes("Asset-Package") || result.downloadUrl.includes("Icon-package"),
-      "downloadUrl should include 'Asset-Package' or 'Icon-package'"
+    assert.equal(result.newVersion, "aws-q1-2026")
+    assert.equal(
+      result.downloadUrl,
+      "https://d1.awsstatic.com/onedam/marketing-channels/website/aws/en_US/architecture/approved/architecture-icons/Icon-package_01302026.31b40d126ed27079b708594940ad577a86150582.zip",
     )
-    assert.match(result.publishedDate, /\d{4}-\d{2}-\d{2}/, "publishedDate should match YYYY-MM-DD format")
-
-    console.log("Live test result:", result)
+    assert.equal(result.publishedDate, "2026-01-30")
   })
 })

--- a/test/resolve-azure-icons.spec.mjs
+++ b/test/resolve-azure-icons.spec.mjs
@@ -1,15 +1,26 @@
 import { describe, it } from "mocha"
 import fetchLatestAzureIconPackage from "../scripts/resolve-azure-icons.mjs"
 import assert from "assert"
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+function mockFetch(html) {
+  return async () => ({
+    ok: true,
+    text: async () => html,
+  })
+}
 
 describe("fetchLatestAzureIconPackage", () => {
-  it("should fetch and parse the latest Icon Package from the live Azure website", async () => {
-    const result = await fetchLatestAzureIconPackage()
+  it("should fetch and parse the latest Icon Package", async () => {
+    const html = readFileSync(resolve("test/fixtures/azure-valid.html"), "utf8")
+    const result = await fetchLatestAzureIconPackage(mockFetch(html))
 
-    assert.match(result.newVersion, /^\d+$/, "newVersion should be a number")
-    assert.ok(result.downloadUrl.includes("Azure_Public_Service_Icons_V"), "downloadUrl should include 'Azure_Public_Service_Icons_V'")
-    assert.match(result.version, /\d+/, "version should be a number")
-
-    console.log("Live test result:", result)
+    assert.equal(result.newVersion, "23")
+    assert.equal(
+      result.downloadUrl,
+      "https://arch-center.azureedge.net/icons/Azure_Public_Service_Icons_V23.zip",
+    )
+    assert.equal(result.version, "23")
   })
 })


### PR DESCRIPTION
Make the AWS and Azure resolver tests deterministic by injecting mocked fetch responses and HTML fixtures. Also guard the resolver scripts so importing them from tests no longer triggers live network calls.